### PR TITLE
R v1.5.3

### DIFF
--- a/Addon/src/rainstar/aw/ability/Air.java
+++ b/Addon/src/rainstar/aw/ability/Air.java
@@ -5,6 +5,7 @@ import daybreak.abilitywar.ability.AbilityManifest;
 import daybreak.abilitywar.ability.AbilityManifest.Rank;
 import daybreak.abilitywar.ability.AbilityManifest.Species;
 import daybreak.abilitywar.game.AbstractGame.Participant;
+import daybreak.abilitywar.utils.base.concurrent.TimeUnit;
 
 @AbilityManifest(name = "공기", rank = Rank.A, species = Species.HUMAN, explain = {
 		"능력도 없는 당신은 존재감이 너무 없는 나머지,", 
@@ -18,11 +19,25 @@ public class Air extends AbilityBase {
 	public Air(Participant participant) {
 		super(participant);
 	}
-	
+
+	private final AbilityTimer passive = new AbilityTimer() {
+		@Override
+		protected void run(int count) {
+			getParticipant().attributes().TARGETABLE.setValue(false);
+		}
+		@Override
+		protected void onEnd() {
+			onSilentEnd();
+		}
+		@Override
+		protected void onSilentEnd() {
+			getParticipant().attributes().TARGETABLE.setValue(true);
+		}
+	}.setPeriod(TimeUnit.TICKS, 1).register();
+
 	@Override
 	protected void onUpdate(Update update) {
-		if (update == Update.RESTRICTION_CLEAR) getParticipant().attributes().TARGETABLE.setValue(false);	
-		if (update == Update.ABILITY_DESTROY || update == Update.RESTRICTION_SET) getParticipant().attributes().TARGETABLE.setValue(true);
+		if (update == Update.RESTRICTION_CLEAR) passive.start();
 	}
 	
 }

--- a/Addon/src/rainstar/aw/ability/Devil.java
+++ b/Addon/src/rainstar/aw/ability/Devil.java
@@ -36,6 +36,7 @@ import org.bukkit.entity.Projectile;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityRegainHealthEvent;
 import org.bukkit.event.entity.EntityRegainHealthEvent.RegainReason;
+import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerArmorStandManipulateEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerToggleSneakEvent;
@@ -182,7 +183,15 @@ public class Devil extends AbilityBase implements ActiveHandler {
 			look.start();
 		}
 	}
-	
+
+	@SubscribeEvent
+	private void onPlayerDeath(PlayerDeathEvent e) {
+		final Contract con = contract.get(e.getEntity());
+		if (con != null) {
+			con.stop(false);
+		}
+	}
+
 	private final AbilityTimer look = new AbilityTimer() {
 		
 		@Override

--- a/Addon/src/rainstar/aw/ability/Mazochist.java
+++ b/Addon/src/rainstar/aw/ability/Mazochist.java
@@ -6,6 +6,7 @@ import daybreak.abilitywar.ability.AbilityManifest;
 import daybreak.abilitywar.ability.AbilityManifest.Rank;
 import daybreak.abilitywar.ability.AbilityManifest.Species;
 import daybreak.abilitywar.ability.SubscribeEvent;
+import daybreak.abilitywar.ability.decorator.ActiveHandler;
 import daybreak.abilitywar.config.ability.AbilitySettings.SettingObject;
 import daybreak.abilitywar.game.AbstractGame.Participant;
 import daybreak.abilitywar.game.AbstractGame.Participant.ActionbarNotification.ActionbarChannel;
@@ -35,7 +36,7 @@ import java.util.List;
 		"§7철괴 우클릭 시§f $[DURATION]초간 감소된 피해를 2회 맞습니다."
 		})
 
-public class Mazochist extends AbilityBase {
+public class Mazochist extends AbilityBase implements ActiveHandler {
 	
 	public Mazochist(Participant participant) {
 		super(participant);
@@ -51,7 +52,7 @@ public class Mazochist extends AbilityBase {
     };
 	
 	public static final SettingObject<Integer> HEAL_AMOUNT = 
-			abilitySettings.new SettingObject<Integer>(Mazochist.class, "heal", 50,
+			abilitySettings.new SettingObject<Integer>(Mazochist.class, "heal", 60,
             "# 스택당 매 틱 회복량", "# 단위: 값 / 10000", "# 10 = 0.001", "# 초당 0.02 회복") {
         @Override
         public boolean condition(Integer value) {

--- a/Addon/src/rainstar/aw/ability/TangerineJuice.java
+++ b/Addon/src/rainstar/aw/ability/TangerineJuice.java
@@ -385,7 +385,7 @@ public class TangerineJuice extends AbilityBase implements ActiveHandler {
 			}
 			
 			for (Player players : LocationUtil.getEntitiesInCircle(Player.class, center, fieldrange, predicate)) {
-				Vector vector = VectorUtil.validateVector(center.toVector().subtract(players.getLocation().toVector()).normalize().setY(0).multiply(0.2));
+				Vector vector = VectorUtil.validateVector(center.toVector().subtract(players.getLocation().toVector()).normalize().setY(0).multiply(0.08));
 				vectors.add(vector);
 				players.setVelocity(vector);
 			}

--- a/Addon/src/rainstar/aw/synergy/Sadism.java
+++ b/Addon/src/rainstar/aw/synergy/Sadism.java
@@ -22,7 +22,7 @@ public class Sadism extends Synergy {
 	}
 	
 	public static final SettingObject<Integer> INCREASE = 
-			synergySettings.new SettingObject<Integer>(Sadism.class, "increase", 25,
+			synergySettings.new SettingObject<Integer>(Sadism.class, "increase", 33,
             "# 타격당 공격력 증가 수치", "# 단위: %") {
         @Override
         public boolean condition(Integer value) {


### PR DESCRIPTION
귤즙 장판의 끌어당기는 힘을 0.2에서 0.08로 조정
데빌이 [착취] 능력을 통해 죽은 대상에게 잠식할 수 있던 문제 및 자연회복 효과를 가져오지 않던 문제 해결
수다쟁이 버그 해결, 이제 무슨 포션 효과가 나오는지 보임
피학증 철괴 우클릭 문제 해결, 스택당 회복 컨피그값을 50에서 60으로 조정(컨피그 초기화 필요)
가학증 공격력 25%에서 33%로 조정(컨피그 초기화 필요)
제로가 NaN 버그를 일으키는 문제 해결
공기가 타게팅 불능이 영구적으로 되지 않던 문제 해결